### PR TITLE
Cannot access property $was_initialized

### DIFF
--- a/src/class-block.php
+++ b/src/class-block.php
@@ -34,6 +34,8 @@ if ( ! class_exists( Block::class ) ) :
 		 * Record if the block was initialized to make sure it is
 		 * initialized at most once.
 		 *
+		 * @since    1.0.1
+		 *           Changed visibility to protected.
 		 * @since    1.0.0
 		 * @var      bool
 		 */


### PR DESCRIPTION
In PHP Versions < 7.4, `private` member variables cannot be accessed in child classes. Thus, `$was_initialized` cannot be accessed in classes that extend `Block`. This causes a fatal error.

Changing the visibility of `$was_initialized` to `protected` makes it accessible in child classes.