### PR TITLE
Remove `should_load_extension_assets`

### DIFF
--- a/src/class-functions.php
+++ b/src/class-functions.php
@@ -257,32 +257,7 @@ if ( ! class_exists( Functions::class ) ) :
 		}
 
 		/**
-		 * Returns if at least one of the blocks from the `requires` field
-		 * is used or if the current screen is the editor screen.
-		 *
-		 * @see       https://developer.wordpress.org/reference/functions/wp_should_load_block_editor_scripts_and_styles/
-		 * @since     1.0.0
-		 * @param     array $extension    Extension data array.
-		 * @return    bool
-		 */
-		private static function should_load_extension_assets( $extension ) {
-			if ( empty( $extension['requires'] ) ) {
-				return true;
-			}
-
-			// Bail early if at least one matching block is found.
-			foreach ( $extension['requires'] as $required_block ) {
-				if ( has_block( $required_block ) ) {
-					return true;
-				}
-			}
-			return wp_should_load_block_editor_scripts_and_styles();
-		}
-
-		/**
 		 * Enqueue all scripts of the given type.
-		 * Assets in the frontend are only enqueued if at least one
-		 * block from `requires` is used.
 		 *
 		 * @since     1.0.0
 		 * @param     string $type    Type of the asset (frontend, editor, both).
@@ -292,7 +267,7 @@ if ( ! class_exists( Functions::class ) ) :
 		private static function enqueue_scripts_by_type( string $type ): void {
 			$extension_registry = Extension_Registry::get_instance();
 			foreach ( $extension_registry->get_registered_extensions() as $extension ) {
-				if ( ! empty( $extension[ $type ] ) && self::should_load_extension_assets( $extension ) ) {
+				if ( ! empty( $extension[ $type ] ) ) {
 					wp_enqueue_script( $extension[ $type ] );
 				}
 			}
@@ -300,8 +275,6 @@ if ( ! class_exists( Functions::class ) ) :
 
 		/**
 		 * Enqueue all styles of the given type.
-		 * Assets in the frontend are only enqueued if at least one
-		 * block from `requires` is used.
 		 *
 		 * @since     1.0.0
 		 * @param     string $type    Type of the asset (frontend, editor, both).
@@ -311,7 +284,7 @@ if ( ! class_exists( Functions::class ) ) :
 		private static function enqueue_styles_by_type( string $type ): void {
 			$extension_registry = Extension_Registry::get_instance();
 			foreach ( $extension_registry->get_registered_extensions() as $extension ) {
-				if ( ! empty( $extension[ $type ] ) && self::should_load_extension_assets( $extension ) ) {
+				if ( ! empty( $extension[ $type ] ) ) {
 					wp_enqueue_style( $extension[ $type ] );
 				}
 			}


### PR DESCRIPTION
`should_load_extension_assets` was used to detect whether a block is present on the current page. In some cases, blocks are added from a template, pattern, or post, such that the block is not actually in the post content but only retrieved in a subsequent step (inside the render method of the containing block). Due to this, `should_load_extension_assets` does not function reliably and prevents extension assets from being enqueued even though they are required. The only way to reliably detect these blocks would be to query the entire content, which may or may not add a substantial number of additional queries.

Also, performing these additional queries would require us to update `wp-block-api` whenever there is a new post block (e.g. slider, team, testimonials, pattern, template-part, etc.).

Thus, I would be in favour of removing this feature for now.